### PR TITLE
Update Readme and github build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: bluebuild
 on:
   schedule:
     - cron:
-        "00 06 * * *" # build at 06:00 UTC every day
-        # (20 minutes after last ublue images start building)
+        "00 06 * * 2" # build at 06:00 UTC every Tuesday
   push:
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
-# BlueBuild Template &nbsp; [![bluebuild build badge](https://github.com/blue-build/template/actions/workflows/build.yml/badge.svg)](https://github.com/blue-build/template/actions/workflows/build.yml)
+# ptschoolslinux
+This is an immutable operating system for the [Port Townsend School District](https://www.ptschools.org/). It uses [blue-build](https://blue-build.org/) for the build system and [Universal Blue](https://universal-blue.org/) for the base images. Upstream of universal blue is [Fedora](https://fedoraproject.org/) a free and open source volunteer backed operating system. Furthermore the project is inspired by [EU-OS](https://eu-os.eu/)
 
-See the [BlueBuild docs](https://blue-build.org/how-to/setup/) for quick setup instructions for setting up your own repository based on this template.
+## Intended use case
+This OS intended to be deployed in an enterprise environment. AD is used for account management and [OpenVox](https://voxpupuli.org/) is used for additional configuration management.
 
-After setup, it is recommended you update this README to describe your custom image.
+Packages and configuration for joining and AD domain and running puppet are layered into the image.
+
+## Available versions
+There are two version of ptschoolslinux: ptschoolslinux and ptschoolslinux-kinoite, based on [gnome](https://www.gnome.org/) and [kde](https://kde.org/) respectively.
+
+
 
 ## Installation
 
+### Rebasing from another fedora atomic OS
 > [!WARNING]  
 > [This is an experimental feature](https://www.fedoraproject.org/wiki/Changes/OstreeNativeContainerStable), try at your own discretion.
 
-To rebase an existing atomic Fedora installation to the latest build:
+To rebase from an existing atomic Fedora installation to the latest build:
 
 - First rebase to the unsigned image, to get the proper signing keys and policies installed:
   ```
-  rpm-ostree rebase ostree-unverified-registry:ghcr.io/blue-build/template:latest
+  rpm-ostree rebase ostree-unverified-registry:ghcr.io/jorussell1/ptschoolslinux:latest
   ```
 - Reboot to complete the rebase:
   ```
@@ -21,7 +29,7 @@ To rebase an existing atomic Fedora installation to the latest build:
   ```
 - Then rebase to the signed image, like so:
   ```
-  rpm-ostree rebase ostree-image-signed:docker://ghcr.io/blue-build/template:latest
+      rpm-ostree rebase ostree-image-signed:docker://ghcr.io/jorussell1/ptschoolslinux:latest
   ```
 - Reboot again to complete the installation
   ```
@@ -39,5 +47,5 @@ If build on Fedora Atomic, you can generate an offline ISO with the instructions
 These images are signed with [Sigstore](https://www.sigstore.dev/)'s [cosign](https://github.com/sigstore/cosign). You can verify the signature by downloading the `cosign.pub` file from this repo and running the following command:
 
 ```bash
-cosign verify --key cosign.pub ghcr.io/blue-build/template
+cosign verify --key cosign.pub ghcr.io/jorussell1/ptschoolslinux
 ```


### PR DESCRIPTION
This change sets the build time to be more appropriate for the GTS version. This mean that updates to the base OS only happen every  Tuesday a few hours after the base gts image is rebuilt. This makes the rollback feature actually function correctly since only the *real* old version will stay behind.

I also updated the readme finally