### PR TITLE
Use evince instead of okular on kinoite

### DIFF
--- a/recipes/kde-modules.yml
+++ b/recipes/kde-modules.yml
@@ -5,7 +5,7 @@ modules:
     install:
       packages:
         - gwenview
-        - okular
+        - evince
   - type: files
     files:
       - source: kde


### PR DESCRIPTION
okular is causing confusion by adding margins to each print job. Evince doesn't do anything like that so I'm going with evince even on kde.