### PR TITLE
Remove KDE default apps hack

### DIFF
--- a/recipes/kde-modules.yml
+++ b/recipes/kde-modules.yml
@@ -9,11 +9,6 @@ modules:
     files:
       - source: kde
         destination: /
-  - type: script
-    snippets:
-      # This is needed to change the default panel favorites on kde and it's ugly and I don't like it
-      - |
-        sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:io.github.kolunmi.Bazaar.desktop,preferred:\/\/filemanager<\/default>/' /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
-      
+
 
 


### PR DESCRIPTION
This is to mirror the change in
https://github.com/ublue-os/aurora/pull/1782/changes

It doesn't seem like there's a real solution as of right now for setting default favorites in kde