### PR TITLE
Add and enable app indicator for gnome

### DIFF
--- a/files/gschema-overrides/zz1-ptschools.gschema.override
+++ b/files/gschema-overrides/zz1-ptschools.gschema.override
@@ -19,5 +19,5 @@ click-method='areas'
 always-show-universal-access-status=true
 
 [org.gnome.shell]
-enabled-extensions=['dash-to-panel@jderose9.github.com','no-overview@fthx', 'wiggle@mechtifs', 'grand-theft-focus@zalckos.github.com', 'caffeine@patapon.info']
+enabled-extensions=['dash-to-panel@jderose9.github.com','no-overview@fthx', 'wiggle@mechtifs', 'grand-theft-focus@zalckos.github.com', 'caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com']
 

--- a/recipes/gnome-modules.yml
+++ b/recipes/gnome-modules.yml
@@ -15,6 +15,7 @@ modules:
       - Wiggle
       - Grand Theft Focus
       - Caffeine
+      - 615 # https://extensions.gnome.org/extension/615/appindicator-support/
   - type: gschema-overrides
     include:
       - zz1-ptschools.gschema.override


### PR DESCRIPTION
This adds support for appindicator for apps like zoom and remmina. The little icon in the panel will show up when the app is running in the background.

modified:   files/gschema-overrides/zz1-ptschools.gschema.override
modified:   recipes/gnome-modules.yml