### PR TITLE
Remove Wiggle extension from gnome

### DIFF
--- a/files/gschema-overrides/zz1-ptschools.gschema.override
+++ b/files/gschema-overrides/zz1-ptschools.gschema.override
@@ -19,5 +19,5 @@ click-method='areas'
 always-show-universal-access-status=true
 
 [org.gnome.shell]
-enabled-extensions=['dash-to-panel@jderose9.github.com','no-overview@fthx', 'wiggle@mechtifs', 'grand-theft-focus@zalckos.github.com', 'caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com']
+enabled-extensions=['dash-to-panel@jderose9.github.com','no-overview@fthx', 'grand-theft-focus@zalckos.github.com', 'caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com']
 

--- a/recipes/gnome-modules.yml
+++ b/recipes/gnome-modules.yml
@@ -4,7 +4,6 @@ modules:
   - type: dnf
     install:
       packages:
-        - loupe	
         - gnome-tweaks
   - type: gnome-extensions
     install:
@@ -12,7 +11,6 @@ modules:
       - Places Status Indicator
       - Dash to Panel
       - 4099 # https://extensions.gnome.org/extension/4099/no-overview/
-      - Wiggle
       - Grand Theft Focus
       - Caffeine
       - 615 # https://extensions.gnome.org/extension/615/appindicator-support/


### PR DESCRIPTION
Fedora 43 ships with gnome 49 and wiggle does not support 49 so it must be removed.

modified:   files/gschema-overrides/zz1-ptschools.gschema.override:
Remove wiggle.
modified:   recipes/gnome-modules.yml: Remove wiggle.