### PR TITLE
Add Lexend font from google-fonts

### DIFF
--- a/recipes/common-modules.yml
+++ b/recipes/common-modules.yml
@@ -67,6 +67,7 @@ modules:
         - Roboto
         - Inter
         - Montserrat
+        - Lexend
       url-fonts:
         - name: MapleMonoNF
           url: https://github.com/subframe7536/maple-font/releases/download/v7.9/MapleMono-NF-unhinted.zip


### PR DESCRIPTION
Lexend is a dyslexic friendly font, and a student showed it to me

modified:   recipes/common-modules.yml